### PR TITLE
Bug: NotFound handler was called although route exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.0.22]() (???)
+
+### Bug Fixes
+
+* fix a case that the notfound handler was called although route exists ([d704aaf](https://github.com/uptrace/bunrouter/pull/97/commits/d704aaf7098151c4196567f1b9d99e0c13ec3d42))
+
 ## [1.0.21](https://github.com/uptrace/bunrouter/compare/v1.0.20...v1.0.21) (2023-11-20)
 
 

--- a/node.go
+++ b/node.go
@@ -143,9 +143,7 @@ func (n *node) _findRoute(meth, path string) (*node, *routeHandler, int) {
 					if handler != nil {
 						return node, handler, wildcardLen
 					}
-					if node != nil {
-						found = node
-					}
+					found = node
 				}
 			}
 		}
@@ -154,8 +152,11 @@ func (n *node) _findRoute(meth, path string) (*node, *routeHandler, int) {
 	if n.colon != nil {
 		if i := strings.IndexByte(path, '/'); i > 0 {
 			node, handler, wildcardLen := n.colon._findRoute(meth, path[i:])
-			if handler != nil {
+			if node != nil && handler != nil {
 				return node, handler, wildcardLen
+			}
+			if found == nil {
+				found = node
 			}
 		} else if n.colon.handlerMap != nil {
 			if handler := n.colon.handlerMap.Get(meth); handler != nil {

--- a/router_test.go
+++ b/router_test.go
@@ -108,12 +108,15 @@ func TestNotFound(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, w.Code)
 	require.Equal(t, 0, calledNotFound)
 
-	// Now try with a custome handler.
+	// Now try with a custom handler.
 	router = New(WithNotFoundHandler(notFoundHandler))
 	router.GET("/user/abc", simpleHandler)
 
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/abc/", nil)
+
 	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, 1, calledNotFound)
 }
 
@@ -127,6 +130,7 @@ func TestMethodNotAllowed(t *testing.T) {
 
 	router := New()
 	router.POST("/abc", simpleHandler)
+	router.GET("/abc/:id/def/:sub_id", simpleHandler)
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/abc", nil)
@@ -135,12 +139,22 @@ func TestMethodNotAllowed(t *testing.T) {
 	require.Equal(t, http.StatusMethodNotAllowed, w.Code)
 	require.Equal(t, 0, calledMethodNotAllowed)
 
-	// Now try with a custome handler.
-	router = New(WithMethodNotAllowedHandler(methodNotAllowedHandler))
-	router.POST("/abc", simpleHandler)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/abc/1/def/2", nil)
 
 	router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	require.Equal(t, 0, calledMethodNotAllowed)
+
+	// Now try with a custom handler.
+	router = New(WithMethodNotAllowedHandler(methodNotAllowedHandler))
+	router.POST("/abc", simpleHandler)
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/abc", nil)
+
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, 1, calledMethodNotAllowed)
 }
 


### PR DESCRIPTION
## 📄 What has changed
There was a bug in the `_findRoute` method of the file `node.go`. Please see the adjusted test `TestMethodNotAllowed` in `router_test.go` as an example. 

## ✅ Before submitting, please be sure to check this list
* [x] your branch will not cause merge conflict with main branch
* [x] unit tests are included
* [x] the CHANGELOG has been updated
* [x] you are not committing extraneous files or sensitive data
